### PR TITLE
Fix checkstyle-suppressions.xml for windows os

### DIFF
--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -22,6 +22,6 @@
 
 <suppressions>
     <!-- Ignore generated sources -->
-    <suppress files=".*/generated-sources/.*" checks=".*"/>
-    <suppress files=".*/generated-test-sources/.*" checks=".*"/>
+    <suppress files=".*[/\\]generated-sources[/\\].*" checks=".*"/>
+    <suppress files=".*[/\\]generated-test-sources[/\\].*" checks=".*"/>
 </suppressions>


### PR DESCRIPTION
This fixes checkstyle-suppressions when running `mvnw clean verify` on a windows machine.