### PR TITLE
Add Notification Badge Component and some small fixes

### DIFF
--- a/components/src/main/java/org/patternfly/component/button/Button.java
+++ b/components/src/main/java/org/patternfly/component/button/Button.java
@@ -64,6 +64,7 @@ import static org.patternfly.style.Classes.modifier;
 import static org.patternfly.style.Classes.plain;
 import static org.patternfly.style.Classes.progress;
 import static org.patternfly.style.Classes.small;
+import static org.patternfly.style.Classes.stateful;
 import static org.patternfly.style.Classes.tertiary;
 import static org.patternfly.style.Classes.warning;
 import static org.patternfly.style.Size.lg;
@@ -249,6 +250,10 @@ public class Button extends BaseComponent<HTMLElement, Button> implements
 
     public Button control() {
         return css(modifier(control));
+    }
+
+    public Button stateful() {
+        return css(modifier(stateful));
     }
 
     public Button block() {

--- a/components/src/main/java/org/patternfly/component/notification/badge/NotificationBadge.java
+++ b/components/src/main/java/org/patternfly/component/notification/badge/NotificationBadge.java
@@ -1,0 +1,222 @@
+/*
+ *  Copyright 2023 Red Hat
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.patternfly.component.notification.badge;
+
+import java.util.Objects;
+
+import org.jboss.elemento.logger.Logger;
+import org.patternfly.component.BaseComponent;
+import org.patternfly.component.ComponentIcon;
+import org.patternfly.component.ComponentType;
+import org.patternfly.component.button.Button;
+import org.patternfly.core.Aria;
+import org.patternfly.handler.ComponentHandler;
+import org.patternfly.icon.PredefinedIcon;
+import org.patternfly.style.Classes;
+
+import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
+
+import static org.patternfly.component.button.Button.button;
+import static org.patternfly.component.notification.badge.NotificationBadgeVariant.attention;
+import static org.patternfly.component.notification.badge.NotificationBadgeVariant.read;
+import static org.patternfly.component.notification.badge.NotificationBadgeVariant.unread;
+import static org.patternfly.style.Classes.modifier;
+
+/**
+ * A notification badge is a visual indicator that alerts users about incoming notifications.
+ * @see <a href="https://www.patternfly.org/components/notification-badge">PatternFly Notification Badge</a>
+ */
+public class NotificationBadge
+        extends BaseComponent<HTMLElement, NotificationBadge> implements ComponentIcon<HTMLElement, NotificationBadge> {
+
+    // ------------------------------------------------------ factory
+
+    public static NotificationBadge notificationBadge() {
+        return new NotificationBadge(button().stateful());
+    }
+
+    // ------------------------------------------------------ instance state
+
+    private static final Logger logger = Logger.getLogger(NotificationBadge.class.getName());
+
+    private final Button button;
+    private int count = 0;
+    private boolean expanded = false;
+    private NotificationBadgeVariant variant;
+    private Element customNormalIcon;
+    private Element customAttentionIcon;
+
+    private NotificationBadge(Button button) {
+        super(ComponentType.NotificationBadge, button.element());
+        this.button = button;
+        read();
+        ariaExpanded(false);
+    }
+
+    @Override
+    public NotificationBadge that() {
+        return this;
+    }
+
+    public boolean expanded() {
+        return expanded;
+    }
+
+    // ------------------------------------------------------ configuration API
+
+    public NotificationBadge ariaLabel(String ariaLabel) {
+        return aria(Aria.label, ariaLabel);
+    }
+
+    // ------------------------------------------------------ variants
+
+    public NotificationBadge read() {
+        return variant(read);
+    }
+
+    public NotificationBadge unread() {
+        return variant(unread);
+    }
+
+    public NotificationBadge attention() {
+        return variant(attention);
+    }
+
+    public NotificationBadge variant(NotificationBadgeVariant variant) {
+        if (variant == null) {
+            logger.warn("Variant cannot be null, ignoring.");
+            return this;
+        }
+        if (this.variant == variant) {
+            return this;
+        }
+        if (this.variant != null) {
+            classList().remove(this.variant.modifierClass);
+        }
+        this.variant = variant;
+        css(variant.modifierClass);
+        applyVariantIconForCurrentState();
+        return this;
+    }
+
+    @Override
+    public NotificationBadge icon(Element icon) {
+        if (icon == null) {
+            return removeIcon();
+        }
+        if (Objects.equals(customNormalIcon, icon)) {
+            return this;
+        }
+        customNormalIcon = icon;
+        if (variant != attention) {
+            button.icon(icon);
+        }
+        return this;
+    }
+
+    public NotificationBadge attentionIcon(Element icon) {
+        if (icon == null) {
+            return removeAttentionIcon();
+        }
+        if (Objects.equals(customAttentionIcon, icon)) {
+            return this;
+        }
+        customAttentionIcon = icon;
+        if (variant == attention) {
+            button.icon(icon);
+        }
+        return this;
+    }
+
+    public NotificationBadge attentionIcon(PredefinedIcon icon) {
+        return attentionIcon(icon != null ? icon.element() : null);
+    }
+
+    @Override
+    public NotificationBadge removeIcon() {
+        if (customNormalIcon == null) {
+            return this;
+        }
+        customNormalIcon = null;
+        if (variant != attention) {
+            button.removeIcon();
+            applyVariantIconForCurrentState();
+        }
+        return this;
+    }
+
+    public NotificationBadge removeAttentionIcon() {
+        if (customAttentionIcon == null) {
+            return this;
+        }
+        customAttentionIcon = null;
+        if (variant == attention) {
+            button.removeIcon();
+            applyVariantIconForCurrentState();
+        }
+        return this;
+    }
+
+    public NotificationBadge expand() {
+        return expand(true);
+    }
+
+    public NotificationBadge expand(boolean expand) {
+        if (this.expanded == expand) {
+            return this;
+        }
+        this.expanded = expand;
+        ariaExpanded(expand);
+        toggle(modifier(Classes.clicked), expand);
+        return this;
+    }
+
+    public NotificationBadge onClick(ComponentHandler<NotificationBadge> actionHandler) {
+        button.onClick((e, c) -> actionHandler.handle(e, this));
+        return this;
+    }
+
+    public NotificationBadge count(int count) {
+        if (count < 0) {
+            logger.warn("Count cannot be negative, ignoring.");
+            return this;
+        }
+        if (this.count == count) {
+            return this;
+        }
+        this.count = count;
+        updateContent();
+        return this;
+    }
+
+    // ------------------------------------------------------ internal helpers
+
+    private void updateContent() {
+        button.text((count > 0) ? String.valueOf(count) : "");
+    }
+
+    private void ariaExpanded(boolean expanded) {
+        button.aria(Aria.expanded, expanded);
+    }
+
+    private void applyVariantIconForCurrentState() {
+        button.icon(
+                (variant == attention) ? customAttentionIcon != null ? customAttentionIcon : variant.defaultIcon.get()
+                        : customNormalIcon != null ? customNormalIcon : variant.defaultIcon.get());
+    }
+}
+

--- a/components/src/main/java/org/patternfly/component/notification/badge/NotificationBadgeVariant.java
+++ b/components/src/main/java/org/patternfly/component/notification/badge/NotificationBadgeVariant.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2023 Red Hat
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.patternfly.component.notification.badge;
+
+import java.util.function.Supplier;
+
+import org.patternfly.style.Classes;
+
+import elemental2.dom.Element;
+
+import static org.patternfly.icon.IconSets.patternfly.attentionBell;
+import static org.patternfly.icon.IconSets.patternfly.bell;
+import static org.patternfly.style.Classes.modifier;
+
+public enum NotificationBadgeVariant {
+    read(modifier(Classes.read), () -> bell().element()),
+    unread(modifier(Classes.unread), () -> bell().element()),
+    attention(modifier(Classes.attention), () -> attentionBell().element());
+
+    public final String modifierClass;
+    public final Supplier<Element> defaultIcon;
+
+    NotificationBadgeVariant(String modifierClass, Supplier<Element> defaultIcon) {
+        this.modifierClass = modifierClass;
+        this.defaultIcon = defaultIcon;
+    }
+}

--- a/core/src/main/java/org/patternfly/style/Classes.java
+++ b/core/src/main/java/org/patternfly/style/Classes.java
@@ -40,6 +40,7 @@ public interface Classes {
     String animateCurrent = "animate-current";
     String ariaDisabled = "aria-disabled";
     String arrow = "arrow";
+    String attention = "attention";
     String autoColumnWidths = "auto-column-widths";
     String autoFit = "auto-fit";
     String avatar = "avatar";
@@ -67,6 +68,7 @@ public interface Classes {
     String chipContainer = "chip-container";
     String chipGroup = "chip-group";
     String clickable = "clickable";
+    String clicked = "clicked";
     String close = "close";
     String code = "code";
     String codeBlock = "code-block";
@@ -252,6 +254,7 @@ public interface Classes {
     String stack = "stack";
     String standalone = "standalone";
     String start = "start";
+    String stateful = "stateful";
     String static_ = "static";
     String status = "status";
     String step = "step";

--- a/core/version.java
+++ b/core/version.java
@@ -15,7 +15,8 @@
  */
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 24+
-//PREVIEW
+//JAVAC_OPTIONS --enable-preview -source 24
+//JAVA_OPTIONS --enable-preview
 
 void main(String... args) throws IOException {
     if (args.length != 3) {

--- a/showcase/common/code.java
+++ b/showcase/common/code.java
@@ -15,7 +15,8 @@
  */
 /// usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 24+
-//PREVIEW
+//JAVAC_OPTIONS --enable-preview -source 24
+//JAVA_OPTIONS --enable-preview
 
 static class SourceSpec {
 
@@ -138,7 +139,7 @@ void addSnippet(StringBuilder out, String name, List<String> code) {
     out.append("\n        snippets.put(\"")
             .append(escapeJava(name))
             .append("\", \"")
-            .append(escapeJava(String.join("\\n", code)))
+            .append(escapeJava(String.join("\n", code)))
             .append("\");");
 }
 

--- a/showcase/common/doc.java
+++ b/showcase/common/doc.java
@@ -15,7 +15,8 @@
  */
 /// usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 24+
-//PREVIEW
+//JAVAC_OPTIONS --enable-preview -source 24
+//JAVA_OPTIONS --enable-preview
 //DEPS com.vladsch.flexmark:flexmark-all:0.64.8
 
 import com.vladsch.flexmark.html.HtmlRenderer;

--- a/showcase/common/src/main/java/org/patternfly/showcase/component/NotificationBadgeComponent.java
+++ b/showcase/common/src/main/java/org/patternfly/showcase/component/NotificationBadgeComponent.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2023 Red Hat
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.patternfly.showcase.component;
+
+import org.jboss.elemento.router.Route;
+import org.patternfly.component.notification.badge.NotificationBadge;
+import org.patternfly.component.notification.badge.NotificationBadgeVariant;
+import org.patternfly.showcase.Snippet;
+import org.patternfly.showcase.SnippetPage;
+
+import static elemental2.dom.DomGlobal.console;
+import static org.jboss.elemento.Elements.div;
+import static org.patternfly.component.notification.badge.NotificationBadge.notificationBadge;
+import static org.patternfly.icon.IconSets.fas.exclamationCircle;
+import static org.patternfly.icon.IconSets.fas.star;
+import static org.patternfly.icon.IconSets.fas.sun;
+import static org.patternfly.icon.IconSets.patternfly.warningTriangle;
+import static org.patternfly.showcase.ApiDoc.Type.component;
+import static org.patternfly.showcase.ApiDoc.Type.other;
+import static org.patternfly.showcase.Code.code;
+import static org.patternfly.showcase.Data.components;
+
+@Route(value = "/components/notification-badge", title = "Notification badge")
+public class NotificationBadgeComponent extends SnippetPage {
+
+    public NotificationBadgeComponent() {
+        super(components.get("notification-badge"));
+
+        startExamples("Basic notification badges showing read, unread, and attention variants, plus expanded state. The count example shows how to supply a numeric indicator.");
+
+        addSnippet(new Snippet("notification-badge-basic", "Basic", code("notification-badge-basic"), () ->
+                // @code-start:notification-badge-basic
+                div()
+                        .add(notificationBadge().ariaLabel("Notifications")
+                                .onClick((e, nb) -> {
+                                    console.log("Read notification badge clicked");
+                                    nb.expand(!nb.expanded());
+                                }))
+                        .add(notificationBadge().ariaLabel("Unread notifications")
+                                .unread()
+                                .onClick((e, nb) -> {
+                                    console.log("Unread notification badge clicked");
+                                    nb.expand(!nb.expanded());
+                                }))
+                        .add(notificationBadge().ariaLabel("Attention notifications")
+                                .attention()
+                                .onClick((e, nb) -> {
+                                    console.log("Attention notification badge clicked");
+                                    nb.expand(!nb.expanded());
+                                }))
+                        .element()
+                // @code-end:notification-badge-basic
+                ));
+
+                addSnippet(new Snippet("notification-badge-with-count", "With count",
+                        code("notification-badge-with-count"), () ->
+                        // @code-start:notification-badge-with-count
+                        div()
+                                .add(notificationBadge().ariaLabel("10 read notifications").count(10)
+                                        .onClick((e, nb) -> {
+                                            console.log("Read notification badge clicked");
+                                            nb.expand(!nb.expanded());
+                                        }))
+                                .add(notificationBadge().ariaLabel("10 unread notifications").unread().count(10)
+                                        .onClick((e, nb) -> {
+                                            console.log("Unread notification badge clicked");
+                                            nb.expand(!nb.expanded());
+                                        }))
+                                .add(notificationBadge().ariaLabel("10 attention notifications").attention().count(10)
+                                        .onClick((e, nb) -> {
+                                            console.log("Attention notification badge clicked");
+                                            nb.expand(!nb.expanded());
+                                        }))
+                        .element()
+                // @code-end:notification-badge-with-count
+        ));
+
+        addSnippet(new Snippet("notification-badge-custom-icons", "Custom icons",
+                code("notification-badge-custom-icons"), () ->
+                // @code-start:notification-badge-custom-icons
+                div()
+                        .add(notificationBadge().ariaLabel("Custom read notifications")
+                                .icon(star())
+                                .onClick((e, nb) -> nb.expand(!nb.expanded())))
+                        .add(notificationBadge().ariaLabel("Custom unread notifications")
+                                .unread()
+                                .icon(sun())
+                                .onClick((e, nb) -> {
+                                    console.log("Custom read notification badge clicked");
+                                    nb.expand(!nb.expanded());
+                                }))
+                        .add(notificationBadge().ariaLabel("Custom attention notifications")
+                                .attention()
+                                .attentionIcon(warningTriangle())
+                                .onClick((e, nb) -> {
+                                    console.log("Custom attention notification badge clicked");
+                                    nb.expand(!nb.expanded());
+                                }))
+                        .add(notificationBadge().ariaLabel("Toggle variants with retained icons")
+                                .unread()
+                                .icon(star())
+                                .attentionIcon(exclamationCircle())
+                                .onClick((e, nb) -> {
+                                    console.log("Toggle variants with retained icons clicked");
+                                    if (nb.expand(!nb.expanded()).expanded()) {
+                                        nb.attention();
+                                    } else {
+                                        nb.unread();
+                                    }
+                                }))
+                        .element()
+        // @code-end:notification-badge-custom-icons
+        ));
+
+        startApiDocs(NotificationBadge.class);
+        addApiDoc(NotificationBadge.class, component);
+        addApiDoc(NotificationBadgeVariant.class, other);
+    }
+}

--- a/showcase/common/src/main/java/org/patternfly/showcase/component/TimestampComponent.java
+++ b/showcase/common/src/main/java/org/patternfly/showcase/component/TimestampComponent.java
@@ -29,7 +29,6 @@ import org.patternfly.component.timestamp.TimestampFormat;
 import org.patternfly.showcase.Snippet;
 import org.patternfly.showcase.SnippetPage;
 
-import static java.util.Calendar.AUGUST;
 import static org.jboss.elemento.Elements.br;
 import static org.jboss.elemento.Elements.div;
 import static org.patternfly.component.timestamp.Timestamp.timestamp;
@@ -101,7 +100,7 @@ public class TimestampComponent extends SnippetPage {
 
         addSnippet(new Snippet("timestamp-custom-content", "Custom content",
                 code("timestamp-custom-content"), () -> {
-            Date pastDateTime = new Date(122, AUGUST, 9, 14, 57);
+            Date pastDateTime = new Date(122, 7, 9, 14, 57);
             return div()
                     .add(timestamp("1 hour ago").dateTime(pastDateTime))
                     .add(br()).add(br())

--- a/showcase/common/src/main/resources/org/patternfly/showcase/components.json
+++ b/showcase/common/src/main/resources/org/patternfly/showcase/components.json
@@ -397,6 +397,7 @@
     "name": "notification-badge",
     "title": "Notification badge",
     "route": "/components/notification-badge",
+    "clazz": "org.patternfly.component.notification.badge.NotificationBadge",
     "illustration": "notification-badge.png",
     "summary": "A <b>notification badge</b> is a visual indicator that alerts users about incoming notifications."
   },


### PR DESCRIPTION
Closes #71 

Some additional fixes:
 - With the new JBang implementation, there was a problem with its preview mode [x]
 - `java.util.Calendar` (and its constants) is not compatible with `j2cl` [x]
 
Regarding the `NotificationBadge` component:
 - I wanted to implement the `Expandable` interface, but it seems to serve a different use case. Most importantly, it changes during "expansion" by adding the `Classes.expanded`, and we don't want that.
 - When thinking about how to implement the read/unread/attention states, I came upon that the button implementation uses normal non-parametrized methods (primary(), secondary(), danger(), ...) instead of something like `buttonStyle(Enum buttonStyle)`, is it because primary and secondary are from interfaces so for the sake of consistency other styles are also implemented like that? Just to be sure I used both approaches (with one utilizing the other).